### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -9,7 +9,7 @@ jobs:
         id: get_version
         run: echo ::set-env name=RELEASE_VERSION::${{github.sha}}
       - name: Build & Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           GIT_COMMIT: ${{ github.sha }}
           CDN_ACCESS_KEY_ID: ${{ secrets.CDN_ACCESS_KEY_ID }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore